### PR TITLE
Fix doc for 1.8.0

### DIFF
--- a/doc/1.7.0/index.html
+++ b/doc/1.7.0/index.html
@@ -65,7 +65,7 @@ meson compile -C build
 </pre> <h1><a class="anchor" id="autotoc_md3"></a>
 API</h1>
 <p>While libxkbcommon's API is somewhat derived from the classic XKB API as found in <code>X11/extensions/XKB.h</code> and friends, it has been substantially reworked to expose fewer internal details to clients.</p>
-<p>See the <a href="https://xkbcommon.org/doc/current/modules.html">API Documentation</a>.</p>
+<p>See the <a href="https://xkbcommon.org/doc/current/topics.html">API Documentation</a>.</p>
 <h1><a class="anchor" id="autotoc_md4"></a>
 Dataset</h1>
 <p>libxkbcommon does not distribute a keymap dataset itself, other than for testing purposes. The most common dataset is xkeyboard-config, which is used by all current distributions for their X11 XKB data. More information on xkeyboard-config is available here: <a href="https://www.freedesktop.org/wiki/Software/XKeyboardConfig">https://www.freedesktop.org/wiki/Software/XKeyboardConfig</a></p>

--- a/doc/1.8.0/index.html
+++ b/doc/1.8.0/index.html
@@ -209,7 +209,7 @@ Complete list of user options</summary>
 <h1><a class="anchor" id="api"></a>
 API</h1>
 <p>While libxkbcommon’s API is somewhat derived from the classic XKB API as found in <code>X11/extensions/XKB.h</code> and friends, it has been substantially reworked to expose fewer internal details to clients.</p>
-<p>See the <a href="https://xkbcommon.org/doc/current/modules.html">API Documentation</a>.</p>
+<p>See the <a href="https://xkbcommon.org/doc/current/topics.html">API Documentation</a>.</p>
 <h1><a class="anchor" id="dataset"></a>
 Dataset</h1>
 <p>libxkbcommon <em>does not distribute a keyboard layout dataset itself</em>, other than for testing purposes. The most common dataset is <b>xkeyboard-config</b>, which is used by all current distributions for their X11 XKB data. Further information on xkeyboard-config is available at its <a href="https://www.freedesktop.org/wiki/Software/XKeyboardConfig">homepage</a> and at its <a href="https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config">repository</a>.</p>

--- a/doc/1.8.0/md_doc_compat.html
+++ b/doc/1.8.0/md_doc_compat.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="6; url=xkbcommon-compatibility.html">
+        <link href="doxygen.css" rel="stylesheet" type="text/css">
+        <link href="doxygen-extra.css" rel="stylesheet" type="text/css">
+        <title>xkbcommon: Page Redirection</title>
+    </head>
+    <body>
+        <div id="top">
+            <div id="titlearea" style="padding: 1em 0 1em 0.5em;">
+                <div id="projectname">
+                    libxkbcommon
+                </div>
+            </div>
+        </div>
+        <div>
+            <div class="header">
+                <div class="headertitle">
+                    <div class="title">🔀 Redirection</div>
+                </div>
+            </div>
+            <div class="contents">
+                <p>This page has been moved.</p>
+                <p>
+                    If you are not redirected automatically,
+                    follow the <a href="xkbcommon-compatibility.html">link to the current page</a>.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/doc/1.8.0/md_doc_keymap_format_text_v1.html
+++ b/doc/1.8.0/md_doc_keymap_format_text_v1.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="6; url=keymap-text-format-v1.html">
+        <link href="doxygen.css" rel="stylesheet" type="text/css">
+        <link href="doxygen-extra.css" rel="stylesheet" type="text/css">
+        <title>xkbcommon: Page Redirection</title>
+    </head>
+    <body>
+        <div id="top">
+            <div id="titlearea" style="padding: 1em 0 1em 0.5em;">
+                <div id="projectname">
+                    libxkbcommon
+                </div>
+            </div>
+        </div>
+        <div>
+            <div class="header">
+                <div class="headertitle">
+                    <div class="title">🔀 Redirection</div>
+                </div>
+            </div>
+            <div class="contents">
+                <p>This page has been moved.</p>
+                <p>
+                    If you are not redirected automatically,
+                    follow the <a href="keymap-text-format-v1.html">link to the current page</a>.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/doc/1.8.0/md_doc_quick_guide.html
+++ b/doc/1.8.0/md_doc_quick_guide.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="6; url=md_doc_2quick-guide.html">
+        <link href="doxygen.css" rel="stylesheet" type="text/css">
+        <link href="doxygen-extra.css" rel="stylesheet" type="text/css">
+        <title>xkbcommon: Page Redirection</title>
+    </head>
+    <body>
+        <div id="top">
+            <div id="titlearea" style="padding: 1em 0 1em 0.5em;">
+                <div id="projectname">
+                    libxkbcommon
+                </div>
+            </div>
+        </div>
+        <div>
+            <div class="header">
+                <div class="headertitle">
+                    <div class="title">🔀 Redirection</div>
+                </div>
+            </div>
+            <div class="contents">
+                <p>This page has been moved.</p>
+                <p>
+                    If you are not redirected automatically,
+                    follow the <a href="md_doc_2quick-guide.html">link to the current page</a>.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/doc/1.8.0/md_doc_rules_format.html
+++ b/doc/1.8.0/md_doc_rules_format.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="6; url=rule-file-format.html">
+        <link href="doxygen.css" rel="stylesheet" type="text/css">
+        <link href="doxygen-extra.css" rel="stylesheet" type="text/css">
+        <title>xkbcommon: Page Redirection</title>
+    </head>
+    <body>
+        <div id="top">
+            <div id="titlearea" style="padding: 1em 0 1em 0.5em;">
+                <div id="projectname">
+                    libxkbcommon
+                </div>
+            </div>
+        </div>
+        <div>
+            <div class="header">
+                <div class="headertitle">
+                    <div class="title">🔀 Redirection</div>
+                </div>
+            </div>
+            <div class="contents">
+                <p>This page has been moved.</p>
+                <p>
+                    If you are not redirected automatically,
+                    follow the <a href="rule-file-format.html">link to the current page</a>.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/doc/1.8.0/md_doc_user_configuration.html
+++ b/doc/1.8.0/md_doc_user_configuration.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="6; url=user-configuration.html">
+        <link href="doxygen.css" rel="stylesheet" type="text/css">
+        <link href="doxygen-extra.css" rel="stylesheet" type="text/css">
+        <title>xkbcommon: Page Redirection</title>
+    </head>
+    <body>
+        <div id="top">
+            <div id="titlearea" style="padding: 1em 0 1em 0.5em;">
+                <div id="projectname">
+                    libxkbcommon
+                </div>
+            </div>
+        </div>
+        <div>
+            <div class="header">
+                <div class="headertitle">
+                    <div class="title">🔀 Redirection</div>
+                </div>
+            </div>
+            <div class="contents">
+                <p>This page has been moved.</p>
+                <p>
+                    If you are not redirected automatically,
+                    follow the <a href="user-configuration.html">link to the current page</a>.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/doc/1.8.0/modules.html
+++ b/doc/1.8.0/modules.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="6; url=topics.html">
+        <link href="doxygen.css" rel="stylesheet" type="text/css">
+        <link href="doxygen-extra.css" rel="stylesheet" type="text/css">
+        <title>xkbcommon: Page Redirection</title>
+    </head>
+    <body>
+        <div id="top">
+            <div id="titlearea" style="padding: 1em 0 1em 0.5em;">
+                <div id="projectname">
+                    libxkbcommon
+                </div>
+            </div>
+        </div>
+        <div>
+            <div class="header">
+                <div class="headertitle">
+                    <div class="title">🔀 Redirection</div>
+                </div>
+            </div>
+            <div class="contents">
+                <p>This page has been moved.</p>
+                <p>
+                    If you are not redirected automatically,
+                    follow the <a href="topics.html">link to the current page</a>.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
- Fix modules page link: it’s now called “topics” (Doxygen breaking change)
- Fix missing cool URIs redirections pages